### PR TITLE
Fixed query params for listing shipments.

### DIFF
--- a/src/Endpoints/Shipments.php
+++ b/src/Endpoints/Shipments.php
@@ -9,13 +9,13 @@ class Shipments extends BaseEndpoint
     protected $endpoint = '/shipments';
 
     /**
-     * Get a list o
+     * Get a list of shipments or query shipments.
      * @param array $query
      * @return \GuzzleHttp\Psr7\Response
      */
     public function listShipments($query = [])
     {
-        return $this->get('', ['form_params' => $query]);
+        return $this->get('', ['query' => $query]);
     }
 
     /**


### PR DESCRIPTION
Hey there, I noticed that query parameters weren't working for listing shipments. I changed it to query.
